### PR TITLE
Rename Instance to Mapper

### DIFF
--- a/_examples/default/main.go
+++ b/_examples/default/main.go
@@ -21,7 +21,8 @@ func main() {
 		},
 	}
 
-	m := mapify.Instance{}.MapAny(s)
+	mapper := mapify.Mapper{}
+	m := mapper.MapAny(s)
 
 	fmt.Printf("%+v", m) // map[IntField:3 Nested:map[Slice:[map[Field:1] map[Field:2]]] PointerToStringField:0x521e00 StringField:str]
 }

--- a/_examples/filter/main.go
+++ b/_examples/filter/main.go
@@ -17,13 +17,13 @@ func main() {
 		VisibleField:  "visible",
 	}
 
-	instance := mapify.Instance{
+	mapper := mapify.Mapper{
 		Filter: func(path string, e mapify.Element) bool {
 			return path == ".VisibleField"
 		},
 	}
 
-	m := instance.MapAny(s)
+	m := mapper.MapAny(s)
 
 	fmt.Printf("%+v", m) // map[VisibleField:visible]
 }

--- a/mapify.go
+++ b/mapify.go
@@ -9,8 +9,8 @@ import (
 	"strconv"
 )
 
-// Instance represents instance of mapper
-type Instance struct {
+// Mapper represents instance of mapper
+type Mapper struct {
 	Filter   Filter
 	Rename   Rename
 	MapValue MapValue
@@ -35,11 +35,11 @@ func (e Element) Name() string {
 	return e.name
 }
 
-func (i Instance) MapAny(v interface{}) interface{} {
+func (i Mapper) MapAny(v interface{}) interface{} {
 	return i.newInstance().mapAny("", v)
 }
 
-func (i Instance) mapAny(path string, v interface{}) interface{} {
+func (i Mapper) mapAny(path string, v interface{}) interface{} {
 	reflectValue := reflect.ValueOf(v)
 
 	switch {
@@ -54,7 +54,7 @@ func (i Instance) mapAny(path string, v interface{}) interface{} {
 	}
 }
 
-func (i Instance) newInstance() Instance {
+func (i Mapper) newInstance() Mapper {
 	if i.Filter == nil {
 		i.Filter = acceptAllFields
 	}
@@ -70,7 +70,7 @@ func (i Instance) newInstance() Instance {
 	return i
 }
 
-func (i Instance) mapStruct(path string, reflectValue reflect.Value) map[string]interface{} {
+func (i Mapper) mapStruct(path string, reflectValue reflect.Value) map[string]interface{} {
 	result := map[string]interface{}{}
 
 	reflectType := reflectValue.Type()
@@ -97,7 +97,7 @@ func (i Instance) mapStruct(path string, reflectValue reflect.Value) map[string]
 	return result
 }
 
-func (i Instance) mapSlice(path string, reflectValue reflect.Value) interface{} {
+func (i Mapper) mapSlice(path string, reflectValue reflect.Value) interface{} {
 	kind := reflectValue.Type().Elem().Kind()
 
 	switch kind {

--- a/mapify_test.go
+++ b/mapify_test.go
@@ -10,15 +10,15 @@ import (
 	"github.com/stretchr/testify/assert"
 )
 
-func TestInstance_MapAny(t *testing.T) {
-	t.Run("for default Instance", func(t *testing.T) {
-		instance := mapify.Instance{}
+func TestMapper_MapAny(t *testing.T) {
+	t.Run("for default Mapper", func(t *testing.T) {
+		mapper := mapify.Mapper{}
 
 		t.Run("should map primitive", func(t *testing.T) {
 			expected := []interface{}{1, 1.0, "str"}
 
 			for _, val := range expected {
-				result := instance.MapAny(val)
+				result := mapper.MapAny(val)
 				assert.Equal(t, val, result)
 			}
 		})
@@ -29,38 +29,38 @@ func TestInstance_MapAny(t *testing.T) {
 			expected := []interface{}{&str, &number}
 
 			for _, val := range expected {
-				result := instance.MapAny(val)
+				result := mapper.MapAny(val)
 				assert.Same(t, val, result)
 			}
 		})
 
 		t.Run("should map nil", func(t *testing.T) {
-			actual := instance.MapAny(nil)
+			actual := mapper.MapAny(nil)
 			assert.Nil(t, actual)
 		})
 
 		t.Run("should map pointer to nil primitive", func(t *testing.T) {
 			var str *string
-			actual := instance.MapAny(str)
+			actual := mapper.MapAny(str)
 			assert.Same(t, str, actual)
 		})
 
 		t.Run("should map an empty struct", func(t *testing.T) {
-			actual := instance.MapAny(struct{}{})
+			actual := mapper.MapAny(struct{}{})
 			assert.IsType(t, map[string]interface{}{}, actual)
 			assert.Empty(t, actual)
 		})
 
 		t.Run("should map a pointer to empty struct", func(t *testing.T) {
 			s := struct{}{}
-			actual := instance.MapAny(&s)
+			actual := mapper.MapAny(&s)
 			assert.IsType(t, map[string]interface{}{}, actual)
 			assert.Empty(t, actual)
 		})
 
 		t.Run("should map a pointer to nil struct", func(t *testing.T) {
 			var s *struct{}
-			actual := instance.MapAny(s)
+			actual := mapper.MapAny(s)
 			assert.Same(t, s, actual)
 		})
 
@@ -69,7 +69,7 @@ func TestInstance_MapAny(t *testing.T) {
 				Field1 string
 				Field2 string
 			}{}
-			actual := instance.MapAny(s)
+			actual := mapper.MapAny(s)
 			expected := map[string]interface{}{
 				"Field1": "",
 				"Field2": "",
@@ -82,14 +82,14 @@ func TestInstance_MapAny(t *testing.T) {
 				field1 string
 				field2 string
 			}{}
-			actual := instance.MapAny(s)
+			actual := mapper.MapAny(s)
 			assert.IsType(t, map[string]interface{}{}, actual)
 			assert.Empty(t, actual)
 		})
 
 		t.Run("should map a struct with field specified", func(t *testing.T) {
 			s := struct{ Field string }{Field: "value"}
-			actual := instance.MapAny(s)
+			actual := mapper.MapAny(s)
 			expected := map[string]interface{}{
 				"Field": s.Field,
 			}
@@ -100,7 +100,7 @@ func TestInstance_MapAny(t *testing.T) {
 			str := "value"
 			s := struct{ Field *string }{Field: &str}
 			// when
-			actual := instance.MapAny(s)
+			actual := mapper.MapAny(s)
 			// then
 			expected := map[string]interface{}{
 				"Field": s.Field,
@@ -110,7 +110,7 @@ func TestInstance_MapAny(t *testing.T) {
 
 		t.Run("should map a struct with nil field", func(t *testing.T) {
 			s := struct{ Field *string }{}
-			actual := instance.MapAny(s)
+			actual := mapper.MapAny(s)
 			expected := map[string]interface{}{
 				"Field": s.Field,
 			}
@@ -122,7 +122,7 @@ func TestInstance_MapAny(t *testing.T) {
 			s := struct{ Nested nestedStruct }{
 				Nested: nestedStruct{Field: "value"},
 			}
-			actual := instance.MapAny(s)
+			actual := mapper.MapAny(s)
 			expected := map[string]interface{}{
 				"Nested": map[string]interface{}{
 					"Field": s.Nested.Field,
@@ -133,7 +133,7 @@ func TestInstance_MapAny(t *testing.T) {
 
 		t.Run("should map a struct with nested nil struct", func(t *testing.T) {
 			s := struct{ Nested *struct{} }{}
-			actual := instance.MapAny(s)
+			actual := mapper.MapAny(s)
 			expected := map[string]interface{}{
 				"Nested": s.Nested,
 			}
@@ -141,26 +141,26 @@ func TestInstance_MapAny(t *testing.T) {
 		})
 
 		t.Run("should map an empty slice of strings", func(t *testing.T) {
-			actual := instance.MapAny([]string{})
+			actual := mapper.MapAny([]string{})
 			assert.Equal(t, []string{}, actual)
 		})
 
 		t.Run("should map an nil slice of strings", func(t *testing.T) {
 			var given []string
-			actual := instance.MapAny(given)
+			actual := mapper.MapAny(given)
 			assert.Equal(t, given, actual)
 		})
 
 		t.Run("should map an slice of two strings", func(t *testing.T) {
 			given := []string{"1", "2"}
-			actual := instance.MapAny(given)
+			actual := mapper.MapAny(given)
 			assert.Equal(t, given, actual)
 		})
 
 		t.Run("should map an slice of pointer to string", func(t *testing.T) {
 			str1 := "1"
 			given := []*string{&str1}
-			actual := instance.MapAny(given)
+			actual := mapper.MapAny(given)
 			assert.Equal(t, given, actual)
 		})
 
@@ -169,7 +169,7 @@ func TestInstance_MapAny(t *testing.T) {
 				{},
 				{},
 			}
-			actual := instance.MapAny(s)
+			actual := mapper.MapAny(s)
 			expected := []map[string]interface{}{
 				{},
 				{},
@@ -183,7 +183,7 @@ func TestInstance_MapAny(t *testing.T) {
 				{Field: "value1"},
 				{Field: "value2"},
 			}
-			actual := instance.MapAny(s)
+			actual := mapper.MapAny(s)
 			expected := []map[string]interface{}{
 				{
 					"Field": s[0].Field,
@@ -201,7 +201,7 @@ func TestInstance_MapAny(t *testing.T) {
 				{{Field: "A1"}, {Field: "A2"}},
 				{{Field: "B1"}, {Field: "B2"}},
 			}
-			actual := instance.MapAny(s)
+			actual := mapper.MapAny(s)
 			expected := [][]map[string]interface{}{
 				{
 					map[string]interface{}{"Field": s[0][0].Field},
@@ -225,7 +225,7 @@ func TestInstance_MapAny(t *testing.T) {
 					{Field: "2"},
 				},
 			}
-			actual := instance.MapAny(s)
+			actual := mapper.MapAny(s)
 			expected := map[string]interface{}{
 				"Nested": []map[string]interface{}{
 					{"Field": s.Nested[0].Field},
@@ -241,26 +241,26 @@ func TestInstance_MapAny(t *testing.T) {
 func TestFilter(t *testing.T) {
 	t.Run("should filter out all struct fields", func(t *testing.T) {
 		s := struct{ A, B string }{}
-		instance := mapify.Instance{
+		mapper := mapify.Mapper{
 			Filter: func(path string, e mapify.Element) bool {
 				return false
 			},
 		}
 		// when
-		v := instance.MapAny(s)
+		v := mapper.MapAny(s)
 		// then
 		assert.Empty(t, v)
 	})
 
 	t.Run("should filter by struct field path", func(t *testing.T) {
 		s := struct{ A, B string }{}
-		instance := mapify.Instance{
+		mapper := mapify.Mapper{
 			Filter: func(path string, e mapify.Element) bool {
 				return path == ".A"
 			},
 		}
 		// when
-		v := instance.MapAny(s)
+		v := mapper.MapAny(s)
 		// then
 		expected := map[string]interface{}{
 			"A": "",
@@ -272,13 +272,13 @@ func TestFilter(t *testing.T) {
 		s := struct {
 			Nested struct{ A string }
 		}{}
-		instance := mapify.Instance{
+		mapper := mapify.Mapper{
 			Filter: func(path string, e mapify.Element) bool {
 				return path == ".Nested" || path == ".Nested.A"
 			},
 		}
 		// when
-		v := instance.MapAny(s)
+		v := mapper.MapAny(s)
 		// then
 		assert.Equal(t, map[string]interface{}{
 			"Nested": map[string]interface{}{"A": ""},
@@ -290,13 +290,13 @@ func TestFilter(t *testing.T) {
 			{Field: "0"},
 			{Field: "1"},
 		}
-		instance := mapify.Instance{
+		mapper := mapify.Mapper{
 			Filter: func(path string, e mapify.Element) bool {
 				return path == "[1].Field"
 			},
 		}
 		// when
-		v := instance.MapAny(s)
+		v := mapper.MapAny(s)
 		// then
 		expected := []map[string]interface{}{
 			{},
@@ -315,13 +315,13 @@ func TestFilter(t *testing.T) {
 				{Field: "B1"},
 			},
 		}
-		instance := mapify.Instance{
+		mapper := mapify.Mapper{
 			Filter: func(path string, e mapify.Element) bool {
 				return path == "[1][1].Field"
 			},
 		}
 		// when
-		v := instance.MapAny(s)
+		v := mapper.MapAny(s)
 		// then
 		expected := [][]map[string]interface{}{
 			{
@@ -336,13 +336,13 @@ func TestFilter(t *testing.T) {
 	})
 
 	t.Run("should filter by field name", func(t *testing.T) {
-		instance := mapify.Instance{
+		mapper := mapify.Mapper{
 			Filter: func(path string, e mapify.Element) bool {
 				return e.Name() == "Field"
 			},
 		}
 		// when
-		v := instance.MapAny(
+		v := mapper.MapAny(
 			struct{ Field string }{
 				Field: "v",
 			},
@@ -355,13 +355,13 @@ func TestFilter(t *testing.T) {
 	})
 
 	t.Run("should filter by value", func(t *testing.T) {
-		instance := mapify.Instance{
+		mapper := mapify.Mapper{
 			Filter: func(path string, e mapify.Element) bool {
 				return e.String() == "keep it"
 			},
 		}
 		// when
-		v := instance.MapAny(
+		v := mapper.MapAny(
 			struct{ Field1, Field2 string }{
 				Field1: "keep it",
 				Field2: "omit this",
@@ -377,13 +377,13 @@ func TestFilter(t *testing.T) {
 
 func TestRename(t *testing.T) {
 	t.Run("should rename struct field", func(t *testing.T) {
-		instance := mapify.Instance{
+		mapper := mapify.Mapper{
 			Rename: func(path string, e mapify.Element) string {
 				return "newName"
 			},
 		}
 		// when
-		v := instance.MapAny(
+		v := mapper.MapAny(
 			struct{ OldName string }{
 				OldName: "v",
 			},
@@ -400,7 +400,7 @@ func TestMapValue(t *testing.T) {
 	mappedValue := "str"
 
 	t.Run("should map struct field", func(t *testing.T) {
-		instance := mapify.Instance{
+		mapper := mapify.Mapper{
 			MapValue: func(path string, e mapify.Element) interface{} {
 				if e.Name() == "Field1" {
 					return mappedValue
@@ -413,7 +413,7 @@ func TestMapValue(t *testing.T) {
 			Field1: 1, Field2: 2,
 		}
 		// when
-		v := instance.MapAny(s)
+		v := mapper.MapAny(s)
 		// then
 		expected := map[string]interface{}{
 			"Field1": mappedValue,
@@ -423,7 +423,7 @@ func TestMapValue(t *testing.T) {
 	})
 
 	t.Run("should map struct field by path", func(t *testing.T) {
-		instance := mapify.Instance{
+		mapper := mapify.Mapper{
 			MapValue: func(path string, e mapify.Element) interface{} {
 				if path == ".Field1" {
 					return mappedValue
@@ -436,7 +436,7 @@ func TestMapValue(t *testing.T) {
 			Field1: 1, Field2: 2,
 		}
 		// when
-		v := instance.MapAny(s)
+		v := mapper.MapAny(s)
 		// then
 		expected := map[string]interface{}{
 			"Field1": mappedValue,


### PR DESCRIPTION
The new name is better. Instance was too generic.
