### PR TITLE
Add support for map conversion

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@
 [![Go Report Card](https://goreportcard.com/badge/github.com/elgopher/mapify)](https://goreportcard.com/report/github.com/elgopher/mapify)
 [![codecov](https://codecov.io/gh/elgopher/mapify/branch/master/graph/badge.svg)](https://codecov.io/gh/elgopher/mapify)
 
-**Highly configurable** struct to map converter. _Will convert maps into other maps as well (work in progress)._
+**Highly configurable** struct to map converter. Converts `map[string]any` into other maps as well.
 
 ## Features
 
@@ -56,3 +56,11 @@ type SomeStruct struct {
 	Field string
 }
 ```
+
+## MapAny algorithm
+
+1. Take an object which is a struct, map or slice.
+2. Traverse entire object looking for nested structs or maps.
+3. **Filter** elements (struct fields, map keys)
+4. **Rename** field names or map keys
+5. **Map** (struct field or map values)

--- a/_examples/maps/main.go
+++ b/_examples/maps/main.go
@@ -1,0 +1,32 @@
+package main
+
+import (
+	"fmt"
+	"strings"
+
+	"github.com/elgopher/mapify"
+)
+
+// This example shows how to filter maps and rename keys
+func main() {
+	s := map[string]interface{}{
+		"key":     "value",
+		"another": "another value",
+	}
+
+	mapper := mapify.Mapper{
+		Filter: func(path string, e mapify.Element) (bool, error) {
+			return path == ".key", nil
+		},
+		Rename: func(path string, e mapify.Element) (string, error) {
+			return strings.ToUpper(e.Name()), nil
+		},
+	}
+
+	result, err := mapper.MapAny(s)
+	if err != nil {
+		panic(err)
+	}
+
+	fmt.Printf("%+v", result) // map[KEY:value]
+}


### PR DESCRIPTION
Mapper.MapAny now supports map conversion. `map[string]any` instances are converted to map[string]interface{}. During conversion usual callbacks are executed: Filter, Rename and MapValue.